### PR TITLE
게시글 페이지네이션 구현

### DIFF
--- a/src/main/java/com/bitstudy/app/controller/ArticleController.java
+++ b/src/main/java/com/bitstudy/app/controller/ArticleController.java
@@ -75,6 +75,7 @@ public class ArticleController {
         map.addAttribute("article", article);
         map.addAttribute("articleComments", article.articleCommentsResponse());
         //
+        map.addAttribute("totalCount", articleService.getArticleCount());
         return "articles/detail";
     }
 }

--- a/src/main/java/com/bitstudy/app/service/ArticleService.java
+++ b/src/main/java/com/bitstudy/app/service/ArticleService.java
@@ -86,8 +86,13 @@ public class ArticleService {
             log.warn("게시글 업데이트 실패. 게시글을 찾을 수 없습니다.");
         }
     }
-
+    /** 게시글 삭제 */
     public void deleteArticle(Long articleId){
         articleRepository.deleteById(articleId);
+    }
+
+    /** 게시글 개수 구하기 - 마지막 글일 경우 '다음' 버튼 비활성화 시키기 위함*/
+    public long getArticleCount() {
+        return articleRepository.count();
     }
 }

--- a/src/main/resources/templates/articles/detail.th.xml
+++ b/src/main/resources/templates/articles/detail.th.xml
@@ -17,13 +17,17 @@
             <attr sel=".media-body/p" th:text="${comment.content}"/>
         </attr>
         <attr sel="#nickname" th:text="${article.nickname}"/>
-        <attr sel="#email" th:text="${article.email}" th:href="${article.email}" />
+        <attr sel="#email" th:text="${article.email}" th:href="@{mailto:${article.email}}" />
         <attr sel="#createdAt" th:text="${#temporals.format(article.registerDate, 'yyyy-MM-dd HH:mm:ss')}"/>
         <attr sel="#hashtag" th:text="${article.hashtag}"/>
+
+        <!--페이징-->
+        <attr sel="nav.blog-pagination">
+            <attr sel="a.btn-outline-primary" th:href="@{*{id} - 1 <= 0 ? '#' : |/articles/*{id-1}|}" th:class="'btn btn-outline-primary rounded-pill' + (*{id} - 1 <= 0 ? ' disabled' : '')" />
+            <attr sel="a.btn-outline-secondary" th:href="@{*{id} >= ${totalCount} ? '#' : |/articles/*{id+1}}" th:class="'btn btn-outline-secondary rounded-pill' + (*{id} >= ${totalCount} ? ' disabled' : '')"/>
+        </attr>
+
     </attr>
-
-
-
 
 
 </thlogic>

--- a/src/main/resources/templates/articles/index.th.xml
+++ b/src/main/resources/templates/articles/index.th.xml
@@ -22,6 +22,6 @@
             <attr sel="a" th:text="${pageNumber + 1}" th:href="@{/articles(page=${pageNumber})}" th:class="'page-link' + (${pageNumber} == ${articles.number}?' disabled':'')" />
         </attr>
 
-        <attr sel="li[2]/a" th:text="다음" th:href="@{/articles(page=${articles.number + 1})}" th:class="'page-link'+(${articles.number} >= ${articles.totalPages}?' disabled':'')" />
+        <attr sel="li[2]/a" th:text="다음" th:href="@{/articles(page=${articles.number + 1})}" th:class="'page-link'+(${articles.number} >= ${articles.totalPages - 1}?' disabled':'')" />
     </attr>
 </thlogic>

--- a/src/test/java/com/bitstudy/app/controller/ArticleControllerTest.java
+++ b/src/test/java/com/bitstudy/app/controller/ArticleControllerTest.java
@@ -77,15 +77,20 @@ class ArticleControllerTest {
     @Test
     void articlePage() throws Exception {
         Long articleId = 1L;
+        long totalCount = 1l;
         given(articleService.getArticle(articleId)).willReturn(createArticleWithCommentsDto());
+        given(articleService.getArticleCount()).willReturn(totalCount);
+
         mvc.perform(get("/articles/1"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(view().name("articles/detail"))
                 .andExpect(model().attributeExists("article"))
-                .andExpect(model().attributeExists("articleComments"));
+                .andExpect(model().attributeExists("articleComments"))
+                .andExpect(model().attributeExists("totalCount"));
 
         then(articleService).should().getArticle(articleId);
+        then(articleService).should().getArticleCount();
     }
 
     @DisplayName("게시글 검색 전용 페이지 - 정상호출")

--- a/src/test/java/com/bitstudy/app/service/ArticleServiceTest.java
+++ b/src/test/java/com/bitstudy/app/service/ArticleServiceTest.java
@@ -39,6 +39,7 @@ class ArticleServiceTest {
     @Mock
     private ArticleRepository articleRepository;
 
+
     /** 테스트 할 기능
      * 1. 검색
      * 2. 각 게시글 선택 시 해당 게시글 상세 페이지 이동
@@ -92,7 +93,18 @@ class ArticleServiceTest {
                 .hasFieldOrPropertyWithValue("hashtag", article.getHashtag());
         then(articleRepository).should().findById(articleId);
     }
-
+    @DisplayName("게시글 수 조회, 게시글 수 반환")
+    @Test
+    public void givenNothing_thenReturnArticleCount() {
+        //Given
+        long expected = 0l;
+        given(articleRepository.count()).willReturn(expected);
+        //When
+        long actual = sut.getArticleCount();
+        //Then
+        assertThat(actual).isEqualTo(expected);
+        then(articleRepository).should().count();
+    }
     /* 게시글 생성 */
     @DisplayName("게시글 정보 입력, 게시글 생성")
     @Test


### PR DESCRIPTION
상세페이지  '이전', '다음' 버튼 기능 구현
첫번째 / 마지막 글에서는 초과 이동 안되도록 비활성화
서비스 로직 추가 : 마지막 글 판단하기 위해 totalCount를 서비스 로직에서 추가

This closes #26 